### PR TITLE
:bug: fix(imports): fixes nested directory imports

### DIFF
--- a/src/blar_graph/graph_construction/core/graph_builder.py
+++ b/src/blar_graph/graph_construction/core/graph_builder.py
@@ -134,6 +134,31 @@ class GraphConstructor:
                 )
         return import_edges
 
+    # Recurssive funtions to relate imports
+    def _relate_imports_and_directory_imports(self, file_node_id: str, path: str, visited_paths=set()):
+        import_edges = []
+        import_alias = self.import_aliases.get(path)
+        targetId = self.global_imports.get(path)
+        if not targetId and import_alias:
+            if isinstance(import_alias, list):
+                for alias in import_alias:
+                    if alias not in visited_paths:
+                        visited_paths.add(alias)
+                        import_edges.extend(
+                            self._relate_imports_and_directory_imports(file_node_id, alias, visited_paths)
+                        )
+            else:
+                targetId = self.global_imports.get(import_alias)
+        if targetId:
+            import_edges.append(
+                {
+                    "sourceId": file_node_id,
+                    "targetId": targetId["id"],
+                    "type": "IMPORTS",
+                }
+            )
+        return import_edges
+
     def _relate_imports(self, imports: dict):
         import_edges = []
         for file_node_id in imports.keys():
@@ -142,18 +167,8 @@ class GraphConstructor:
                     related_imports = self._relate_wildcard_imports(file_node_id, path)
                     import_edges.extend(related_imports)
                     continue
-                import_alias = self.import_aliases.get(f"{path}.{imp}")
-                targetId = self.global_imports.get(f"{path}.{imp}")
-                if not targetId and import_alias:
-                    targetId = self.global_imports.get(import_alias)
-                if targetId:
-                    import_edges.append(
-                        {
-                            "sourceId": file_node_id,
-                            "targetId": targetId["id"],
-                            "type": "IMPORTS",
-                        }
-                    )
+                import_edges.extend(self._relate_imports_and_directory_imports(file_node_id, f"{path}.{imp}"))
+
         return import_edges
 
     def __get_directory(self, node, function_call: str, imports: dict):
@@ -176,6 +191,13 @@ class GraphConstructor:
                 if import_alias in self.import_aliases:
                     directory = self.import_aliases[wildcard_path + "." + function_call.split(".")[0]]
                     break
+
+        if isinstance(directory, list):
+            candidates = [s for s in directory if s.endswith(function_call.split(".")[-1])]
+            if len(candidates) == 1:
+                directory = candidates[0]
+            else:
+                directory = ""
 
         for module in function_call.split("."):
             final_module = "." + module

--- a/src/blar_graph/graph_construction/languages/python/python_parser.py
+++ b/src/blar_graph/graph_construction/languages/python/python_parser.py
@@ -23,6 +23,8 @@ class PythonParser(BaseParser):
         current_dir = start_dir
         components = module_name.split(".")
 
+        # Make sure to find in the same directory as the root
+        project_root = os.sep.join(project_root.split(os.sep)[:-1])
         # Try to find the module by traversing up towards the root until the module path is found or root is reached
         while current_dir.startswith(project_root):
             possible_path = os.path.join(current_dir, *components)


### PR DESCRIPTION
fixes: #79 

The bug was produced when there where nested imports. 

For example:
pvlib/__init__.py imports pvlib/iotools which is a directory instead of a file (defined with its own __init__.py).

This caused the import_alias to be a list of imports instead of a single import.

To fix this a recursive function was created that decomposes the lists into single objects and processes them individually. This way we can make sure that the amount of nested directories doesn't matter we always get to the root.

