### PR TITLE
:bug: fix(neo4j): Fixed edge creation in Neo4j

### DIFF
--- a/src/blar_graph/db_managers/neo4j_manager.py
+++ b/src/blar_graph/db_managers/neo4j_manager.py
@@ -41,12 +41,10 @@ class Neo4jManager(BaseDBManager):
 
     def create_node_id_index(self):
         with self.driver.session() as session:
-            node_types = ["CLASS", "FUNCTION", "FILE", "PACKAGE", "FOLDER"]
-            for node_type in node_types:
-                node_query = f"""
-                CREATE INDEX node_id_{node_type} IF NOT EXISTS FOR (n:{node_type}) ON (n.node_id)
-                """
-                session.run(node_query)
+            node_query = """
+            CREATE INDEX node_id_NODE IF NOT EXISTS FOR (n:NODE) ON (n.node_id)
+            """
+            session.run(node_query)
 
     def close(self):
         # Close the connection to the database
@@ -217,7 +215,7 @@ class Neo4jManager(BaseDBManager):
         node_creation_query = """
         CALL apoc.periodic.iterate(
             "UNWIND $nodeList AS node RETURN node",
-            "CALL apoc.create.node([node.type], apoc.map.merge(node.attributes, {repo_id: $repo_id})) YIELD node as n RETURN count(n) as count",
+            "CALL apoc.create.node([node.type, 'NODE'], apoc.map.merge(node.attributes, {repo_id: $repo_id})) YIELD node as n RETURN count(n) as count",
             {batchSize: $batchSize, parallel: true, iterateList: true, params: {nodeList: $nodeList, repo_id: $repo_id}}
         )
         YIELD batches, total, errorMessages, updateStatistics
@@ -236,7 +234,7 @@ class Neo4jManager(BaseDBManager):
         edge_creation_query = """
         CALL apoc.periodic.iterate(
             'WITH $edgesList AS edges UNWIND edges AS edgeObject RETURN edgeObject',
-            'MATCH (node1: edgeObject.sourceType {node_id: edgeObject.sourceId}) MATCH (node2: edgeObject.targetType {node_id: edgeObject.targetId}) CALL apoc.create.relationship(node1, edgeObject.type, {}, node2) YIELD rel RETURN rel',
+            'MATCH (node1:NODE {node_id: edgeObject.sourceId}) MATCH (node2:NODE {node_id: edgeObject.targetId}) CALL apoc.create.relationship(node1, edgeObject.type, {}, node2) YIELD rel RETURN rel',
             {batchSize:$batchSize, parallel:true, iterateList: true, params:{edgesList:$edgesList}}
         )
         YIELD batches, total, errorMessages, updateStatistics

--- a/src/blar_graph/graph_construction/core/graph_builder.py
+++ b/src/blar_graph/graph_construction/core/graph_builder.py
@@ -282,13 +282,6 @@ class GraphConstructor:
 
         return constructors_calls_relations
 
-    def _add_node_types_to_relationships(self, nodes, relationships):
-        nodes_dict = {node["attributes"]["node_id"]: node["type"] for node in nodes}
-        for relationship in relationships:
-            relationship["sourceType"] = nodes_dict[relationship["sourceId"]]
-            relationship["targetType"] = nodes_dict[relationship["targetId"]]
-        return relationships
-
     def build_graph(self, path):
         # process every node to create the graph structure
         nodes, relationships, imports = self._scan_directory(path)
@@ -296,6 +289,5 @@ class GraphConstructor:
         relationships.extend(self._relate_imports(imports))
         # relate functions calls
         relationships.extend(self._relate_constructor_calls(nodes, imports))
-        relationships = self._add_node_types_to_relationships(nodes, relationships)
 
         self.graph_manager.save_graph(nodes, relationships)


### PR DESCRIPTION
Fixed bug in creation node, because of the query planner of Neo4j you can't input dynamic values as node labels.

The solution consists on assigning all nodes a standard label called NODE, then creating an index on that label.